### PR TITLE
Set permissions on files/directories during creation (+ small warning/analyzer fixes)

### DIFF
--- a/CURLHandleSource/CURLFTPSession.h
+++ b/CURLHandleSource/CURLFTPSession.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Karelia Software. All rights reserved.
 //
 
-#import <CURLHandle/CURLHandle.h>
+#import "CURLHandle.h"
 
 
 @protocol CURLFTPSessionDelegate;
@@ -36,7 +36,7 @@
 
 - (BOOL)createFileAtPath:(NSString *)path contents:(NSData *)data permissions:(NSNumber *)permissions withIntermediateDirectories:(BOOL)createIntermediates error:(NSError **)error;
 
-- (BOOL)createDirectoryAtPath:(NSString *)path withIntermediateDirectories:(BOOL)createIntermediates error:(NSError **)error;
+- (BOOL)createDirectoryAtPath:(NSString *)path permissions:(NSNumber *)permissions withIntermediateDirectories:(BOOL)createIntermediates error:(NSError **)error;
 
 - (BOOL)removeFileAtPath:(NSString *)path error:(NSError **)error;
 

--- a/CURLHandleSource/CURLHandle+extras.m
+++ b/CURLHandleSource/CURLHandle+extras.m
@@ -198,13 +198,13 @@ headers = {body = "Content-Type: text/html; filename = \"hello.html\""}
 			
 		if (customHeader) {
 			// create the header structure 
-			struct curl_slist *headers = NULL;
-			headers = curl_slist_append(headers, [customHeader UTF8String]);
+			struct curl_slist *curlHeaders = NULL;
+			curlHeaders = curl_slist_append(curlHeaders, [customHeader UTF8String]);
 
 			// add the value to the form using the custom header
 			curl_formadd(&post, &last, CURLFORM_COPYNAME, [key UTF8String], 
 							 CURLFORM_COPYCONTENTS, valueCString, 
-							 CURLFORM_CONTENTHEADER, headers, CURLFORM_END);
+							 CURLFORM_CONTENTHEADER, curlHeaders, CURLFORM_END);
 		} else {
 			// add the value to the form using just the default header
 			curl_formadd(&post, &last, CURLFORM_COPYNAME, [key UTF8String],

--- a/CURLHandleSource/CURLHandle.h
+++ b/CURLHandleSource/CURLHandle.h
@@ -115,8 +115,8 @@ extern int curlDebugFunction(CURL *mCURL, curl_infotype infoType, char *info, si
 
 @interface NSMutableURLRequest (CURLOptionsFTP)
 
-@property(nonatomic, copy, readwrite, setter=curl_setPostTransferCommands:) NSArray *curl_postTransferCommands;
-@property(nonatomic, readwrite, setter=curl_setCreateIntermediateDirectories:) NSUInteger curl_createIntermediateDirectories;
+- (void)curl_setPostTransferCommands:(NSArray *)postTransferCommands;
+- (void)curl_setCreateIntermediateDirectories:(NSUInteger)createIntermediateDirectories;
 
 @end
 

--- a/CURLHandleSource/CURLHandle.m
+++ b/CURLHandleSource/CURLHandle.m
@@ -292,7 +292,7 @@ int curlDebugFunction(CURL *mCURL, curl_infotype infoType, char *info, size_t in
          
          "*/
         
-        long timeout = [request timeoutInterval];
+        long timeout = (long)[request timeoutInterval];
         curl_easy_setopt([self curl], CURLOPT_NOSIGNAL, timeout != 0);
         curl_easy_setopt([self curl], CURLOPT_CONNECTTIMEOUT, timeout);
         curl_easy_setopt([self curl], CURLOPT_TIMEOUT, timeout);
@@ -402,27 +402,27 @@ int curlDebugFunction(CURL *mCURL, curl_infotype infoType, char *info, size_t in
         
         // Set the HTTP Headers.  (These will override options set with above)
         {
-            for (NSString *theKey in [request allHTTPHeaderFields])
+            for (NSString *headerKey in [request allHTTPHeaderFields])
             {
-                NSString *theValue = [request valueForHTTPHeaderField:theKey];
+                NSString *theValue = [request valueForHTTPHeaderField:headerKey];
                 
                 // Range requests are a special case that should inform Curl directly
 #define HTTP_RANGE_PREFIX @"bytes="
-                if ([theKey caseInsensitiveCompare:@"Range"] == NSOrderedSame &&
+                if ([headerKey caseInsensitiveCompare:@"Range"] == NSOrderedSame &&
                     [theValue hasPrefix:HTTP_RANGE_PREFIX])
                 {
                     curl_easy_setopt(mCURL, CURLOPT_RANGE, [[theValue substringFromIndex:[HTTP_RANGE_PREFIX length]] UTF8String]);
                 }
                 
                 // Accept-Encoding requests are also special
-                else if ([theKey caseInsensitiveCompare:@"Accept-Encoding"] == NSOrderedSame)
+                else if ([headerKey caseInsensitiveCompare:@"Accept-Encoding"] == NSOrderedSame)
                 {
                     curl_easy_setopt(mCURL, CURLOPT_ENCODING, [theValue UTF8String]);
                 }
                 
                 else
                 {
-                    NSString *pair = [NSString stringWithFormat:@"%@: %@",theKey,theValue];
+                    NSString *pair = [NSString stringWithFormat:@"%@: %@",headerKey,theValue];
                     httpHeaders = curl_slist_append( httpHeaders, [pair UTF8String] );
                 }
             }
@@ -487,7 +487,6 @@ int curlDebugFunction(CURL *mCURL, curl_infotype infoType, char *info, size_t in
         [_uploadStream release]; _uploadStream = nil;
         
         // Response
-#warning We can't really assume a header encoding, trying 7-bit ASCII only.  Maybe there is some way to know?
         
         if (nil != httpHeaders)
         {
@@ -661,8 +660,8 @@ int curlDebugFunction(CURL *mCURL, curl_infotype infoType, char *info, size_t in
                         }
                         
                     }
-                    [headerString release];
                 }
+				[headerString release];
             }
             
             
@@ -784,6 +783,7 @@ int curlDebugFunction(CURL *mCURL, curl_infotype infoType, char *info, size_t in
                 = (NSString *) CFURLCreateStringByAddingPercentEscapes(
                                                                        NULL, (CFStringRef) [aValue description], NULL, (CFStringRef) @";:@&=/+", cfStrEnc);
                 [s appendFormat:@"%@=%@&", escapedKey, escapedObject];
+				[escapedObject release];
             }
         }
         else
@@ -792,7 +792,9 @@ int curlDebugFunction(CURL *mCURL, curl_infotype infoType, char *info, size_t in
             = (NSString *) CFURLCreateStringByAddingPercentEscapes(
                                                                    NULL, (CFStringRef) [keyObject description], NULL, (CFStringRef) @";:@&=/+", cfStrEnc);
             [s appendFormat:@"%@=%@&", escapedKey, escapedObject];
+			[escapedObject release];
         }
+		[escapedKey release];
 	}
 	// Delete final & from the string
 	if (![s isEqualToString:@""])
@@ -839,6 +841,7 @@ int curlDebugFunction(CURL *mCURL, curl_infotype infoType, char *info, size_t in
 	NSArray *components = [self componentsSeparatedByLineSeparators];
 	NSEnumerator *theEnum = [components objectEnumerator];
 	NSString *theLine = [theEnum nextObject];		// result code -- ignore
+	(void)theLine;
 	while (nil != (theLine = [theEnum nextObject]) )
 	{
 		if ([[theLine headerKey] isEqualToString:inKey])
@@ -874,6 +877,7 @@ int curlDebugFunction(CURL *mCURL, curl_infotype infoType, char *info, size_t in
 	
 	NSEnumerator *theEnum = [components objectEnumerator];
 	NSString *theLine = [theEnum nextObject];		// result code -- ignore
+	(void)theLine;
 	while (nil != (theLine = [theEnum nextObject]) )
 	{
 		NSString *key = [theLine headerKey];
@@ -920,8 +924,8 @@ int curlDebugFunction(CURL *mCURL, curl_infotype infoType, char *info, size_t in
 {
 	NSMutableArray *result	= [NSMutableArray array];
 	NSRange range = NSMakeRange(0,0);
-	unsigned start, end;
-	unsigned contentsEnd = 0;
+	NSUInteger start, end;
+	NSUInteger contentsEnd = 0;
 	
 	while (contentsEnd < [self length])
 	{


### PR DESCRIPTION
Pretty straightforward. This just lets you set permissions on files and directories during creation. I made it use an NSNumber storing an unsigned long because that's what I saw ConnectionKit doing. Let me know if there's anything you want me to do differently.
